### PR TITLE
Added a processContent option

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -80,6 +80,16 @@ module.exports = function(grunt) {
         files: {
           "tmp/ns_nested_this.js": ["test/fixtures/template.html"]
         }
+      },
+      process_content: {
+        options: {
+          processContent: function (src) {
+            return src.replace(/(^\s+|\s+$)/gm, '');
+          }
+        },
+        files: {
+          "tmp/process_content.js": ["test/fixtures/indent_template.html"]
+        }
       }
     },
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,22 @@ options: {
 }
 ```
 
+#### processContent
+Type: ```function```
+
+This option accepts a function which takes one argument (the file content) and
+returns a string which will be used as template string.
+The example below strips whitespace characters from the beginning and the end of
+each line.
+
+```javascript
+options: {
+  processContent: function(src) {
+    return src.replace(/(^\s+|\s+$)/gm, '');
+  }
+}
+```
+
 ### Usage Examples
 
 ```js
@@ -119,14 +135,14 @@ jst: {
 
 ## Release History
 
- * 2012-10-11   v0.3.1   Rename grunt-contrib-lib dep to grunt-lib-contrib.
- * 2012-08-22   v0.3.0   Options no longer accepted from global config key.
- * 2012-08-15   v0.2.3   Support for nested namespaces.
- * 2012-08-11   v0.2.2   Added processName functionality & escaping single quotes in filenames.
- * 2012-08-09   v0.2.0   Refactored from grunt-contrib into individual repo.
+ * 2012-10-12   v0.3.1   Rename grunt-contrib-lib dep to grunt-lib-contrib.
+ * 2012-08-23   v0.3.0   Options no longer accepted from global config key.
+ * 2012-08-16   v0.2.3   Support for nested namespaces.
+ * 2012-08-12   v0.2.2   Added processName functionality & escaping single quotes in filenames.
+ * 2012-08-10   v0.2.0   Refactored from grunt-contrib into individual repo.
 
 ---
 
 Task submitted by [Tim Branyen](http://tbranyen.com)
 
-*This file was generated on Wed Nov 28 2012 08:40:57.*
+*This file was generated on Sat Dec 29 2012 22:17:11.*

--- a/docs/jst-options.md
+++ b/docs/jst-options.md
@@ -75,3 +75,19 @@ options: {
   amdWrapper: true
 }
 ```
+
+## processContent
+Type: ```function```
+
+This option accepts a function which takes one argument (the file content) and
+returns a string which will be used as template string.
+The example below strips whitespace characters from the beginning and the end of
+each line.
+
+```javascript
+options: {
+  processContent: function(src) {
+    return src.replace(/(^\s+|\s+$)/gm, '');
+  }
+}
+```

--- a/tasks/jst.js
+++ b/tasks/jst.js
@@ -20,7 +20,8 @@ module.exports = function(grunt) {
     var helpers = require('grunt-lib-contrib').init(grunt);
     var options = this.options({
       namespace: 'JST',
-      templateSettings: {}
+      templateSettings: {},
+      processContent: function (src) { return src; }
     });
 
     // assign filename transformation functions
@@ -33,7 +34,7 @@ module.exports = function(grunt) {
 
     var files = this.file.src;
     var output = files.map(function(file) {
-      var src = grunt.file.read(file);
+      var src = options.processContent(grunt.file.read(file));
 
       try {
         compiled = _.template(src, false, options.templateSettings).source;

--- a/test/expected/process_content.js
+++ b/test/expected/process_content.js
@@ -1,0 +1,11 @@
+this["JST"] = this["JST"] || {};
+
+this["JST"]["test/fixtures/indent_template.html"] = function(obj){
+var __p='';var print=function(){__p+=Array.prototype.join.call(arguments, '')};
+with(obj||{}){
+__p+='<div>\n<div>\n<div>\n'+
+( name )+
+'\n</div>\n</div>\n</div>';
+}
+return __p;
+};

--- a/test/fixtures/indent_template.html
+++ b/test/fixtures/indent_template.html
@@ -1,0 +1,7 @@
+<div>
+  <div>
+    <div>
+      <%= name %>
+    </div>
+  </div>
+</div>

--- a/test/jst_test.js
+++ b/test/jst_test.js
@@ -6,7 +6,7 @@ exports['jst'] = {
 
     var expect, result;
 
-    test.expect(7);
+    test.expect(8);
 
     expect = grunt.file.read("test/expected/jst.js");
     result = grunt.file.read("tmp/jst.js");
@@ -36,6 +36,10 @@ exports['jst'] = {
     result = grunt.file.read("tmp/pretty_amd.js");
     test.equal(expect, result, "should make the AMD wrapper output pretty");
     
+    expect = grunt.file.read("test/expected/process_content.js");
+    result = grunt.file.read("tmp/process_content.js");
+    test.equal(expect, result, "should convert file content");
+
     test.done();
   }
 };


### PR DESCRIPTION
This patch adds a `processContent` option which converts file content before processing `_.template`
