### PR TITLE
Replace Underscore.js with Lo-Dash 

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "underscore": "~1.3.3",
+    "lodash": "~1.0.0",
     "grunt-lib-contrib": "~0.3.0"
   },
   "devDependencies": {

--- a/tasks/jst.js
+++ b/tasks/jst.js
@@ -10,7 +10,7 @@
 
 module.exports = function(grunt) {
 
-  var _ = require('underscore');
+  var _ = require('lodash');
 
   // filename conversion for templates
   var defaultProcessName = function(name) { return name; };

--- a/test/expected/amd_wrapper.js
+++ b/test/expected/amd_wrapper.js
@@ -2,14 +2,13 @@ define(function(){
 
 this["JST"] = this["JST"] || {};
 
-this["JST"]["test/fixtures/template.html"] = function(obj){
-var __p='';var print=function(){__p+=Array.prototype.join.call(arguments, '')};
-with(obj||{}){
-__p+='<head><title>'+
-( title )+
+this["JST"]["test/fixtures/template.html"] = function(obj) {
+obj || (obj = {});
+var __t, __p = '', __e = _.escape, __d = obj.obj || obj;
+__p += '<head><title>' +
+((__t = ( obj.title )) == null ? '' : __t) +
 '</title></head>';
-}
-return __p;
+return __p
 };
 
   return this["JST"];

--- a/test/expected/jst.js
+++ b/test/expected/jst.js
@@ -1,11 +1,10 @@
 this["JST"] = this["JST"] || {};
 
-this["JST"]["test/fixtures/template.html"] = function(obj){
-var __p='';var print=function(){__p+=Array.prototype.join.call(arguments, '')};
-with(obj||{}){
-__p+='<head><title>'+
-( title )+
+this["JST"]["test/fixtures/template.html"] = function(obj) {
+obj || (obj = {});
+var __t, __p = '', __e = _.escape, __d = obj.obj || obj;
+__p += '<head><title>' +
+((__t = ( obj.title )) == null ? '' : __t) +
 '</title></head>';
-}
-return __p;
+return __p
 };

--- a/test/expected/ns_nested.js
+++ b/test/expected/ns_nested.js
@@ -2,12 +2,11 @@ this["MyApp"] = this["MyApp"] || {};
 this["MyApp"]["JST"] = this["MyApp"]["JST"] || {};
 this["MyApp"]["JST"]["Main"] = this["MyApp"]["JST"]["Main"] || {};
 
-this["MyApp"]["JST"]["Main"]["test/fixtures/template.html"] = function(obj){
-var __p='';var print=function(){__p+=Array.prototype.join.call(arguments, '')};
-with(obj||{}){
-__p+='<head><title>'+
-( title )+
+this["MyApp"]["JST"]["Main"]["test/fixtures/template.html"] = function(obj) {
+obj || (obj = {});
+var __t, __p = '', __e = _.escape, __d = obj.obj || obj;
+__p += '<head><title>' +
+((__t = ( obj.title )) == null ? '' : __t) +
 '</title></head>';
-}
-return __p;
+return __p
 };

--- a/test/expected/pretty.js
+++ b/test/expected/pretty.js
@@ -1,3 +1,3 @@
 this["JST"] = this["JST"] || {};
 
-this["JST"]["test/fixtures/template.html"] = function(obj){var __p='';var print=function(){__p+=Array.prototype.join.call(arguments, '')};with(obj||{}){__p+='<head><title>'+( title )+'</title></head>';}return __p;};
+this["JST"]["test/fixtures/template.html"] = function(obj) {obj || (obj = {});var __t, __p = '', __e = _.escape, __d = obj.obj || obj;__p += '<head><title>' +((__t = ( obj.title )) == null ? '' : __t) +'</title></head>';return __p};

--- a/test/expected/pretty_amd.js
+++ b/test/expected/pretty_amd.js
@@ -2,7 +2,7 @@ define(function(){
 
   this["JST"] = this["JST"] || {};
 
-  this["JST"]["test/fixtures/template.html"] = function(obj){var __p='';var print=function(){__p+=Array.prototype.join.call(arguments, '')};with(obj||{}){__p+='<head><title>'+( title )+'</title></head>';}return __p;};
+  this["JST"]["test/fixtures/template.html"] = function(obj) {obj || (obj = {});var __t, __p = '', __e = _.escape, __d = obj.obj || obj;__p += '<head><title>' +((__t = ( obj.title )) == null ? '' : __t) +'</title></head>';return __p};
 
   return this["JST"];
 });

--- a/test/expected/process_content.js
+++ b/test/expected/process_content.js
@@ -1,11 +1,10 @@
 this["JST"] = this["JST"] || {};
 
-this["JST"]["test/fixtures/indent_template.html"] = function(obj){
-var __p='';var print=function(){__p+=Array.prototype.join.call(arguments, '')};
-with(obj||{}){
-__p+='<div>\n<div>\n<div>\n'+
-( name )+
+this["JST"]["test/fixtures/indent_template.html"] = function(obj) {
+obj || (obj = {});
+var __t, __p = '', __e = _.escape, __d = obj.obj || obj;
+__p += '<div>\n<div>\n<div>\n' +
+((__t = ( obj.name )) == null ? '' : __t) +
 '\n</div>\n</div>\n</div>';
-}
-return __p;
+return __p
 };

--- a/test/expected/uglyfile.js
+++ b/test/expected/uglyfile.js
@@ -1,9 +1,8 @@
 this["JST"] = this["JST"] || {};
 
-this["JST"]["test/fixtures/it's-a-bad-filename.html"] = function(obj){
-var __p='';var print=function(){__p+=Array.prototype.join.call(arguments, '')};
-with(obj||{}){
-__p+='never name your file like this.';
-}
-return __p;
+this["JST"]["test/fixtures/it's-a-bad-filename.html"] = function(obj) {
+obj || (obj = {});
+var __t, __p = '', __e = _.escape, __d = obj.obj || obj;
+__p += 'never name your file like this.';
+return __p
 };


### PR DESCRIPTION
I propose to switch from underscore to lo-dash. It is 100% replacement with identical API. General reason is performance.

Here I'm posting results of benchmark running on lodash.com on my idle Macbook in Chrome 23 (V8 as node).

![chrome](https://f.cloud.github.com/assets/295197/36929/be89154c-5388-11e2-8786-8190f7b14cd4.png)
