### PR TITLE
Add the filepath for the JST that failed to compile

### DIFF
--- a/tasks/jst.js
+++ b/tasks/jst.js
@@ -53,7 +53,7 @@ module.exports = function(grunt) {
           compiled = _.template(src, false, options.templateSettings).source;
         } catch (e) {
           grunt.log.error(e);
-          grunt.fail.warn('JST failed to compile.');
+          grunt.fail.warn('JST "' + filepath + '" failed to compile.');
         }
 
         if (options.prettify) {


### PR DESCRIPTION
Adds the value of filepath to the console output to let the developer know which file to look in for the errors that may have occurred.
