### PR TITLE
Clarification about interpolation setting in the README. Fixes #29.

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ jst: {
   }
 }
 ```
-
+Note that the `interpolate: /\{\{(.+?)\}\}/g` setting above is simply an example of overwriting lodash's default interpolation. If you want to parse templates with the default `_.template` behavior (i.e. using `<div><%= this.id %></div>`), there's no need to overwrite `templateSettings.interpolate`.
 
 ## Release History
 


### PR DESCRIPTION
Clearing up the Usage Example in the README since a few people (including myself) misunderstood the interpolation example. Thanks! :cactus: 
