### PR TITLE
allow to set template compiler

### DIFF
--- a/tasks/jst.js
+++ b/tasks/jst.js
@@ -22,7 +22,8 @@ module.exports = function(grunt) {
       namespace: 'JST',
       templateSettings: {},
       processContent: function (src) { return src; },
-      separator: lf + lf
+      separator: lf + lf,
+      template: _.template
     });
 
     // assign filename transformation functions
@@ -48,7 +49,7 @@ module.exports = function(grunt) {
         var compiled, filename;
 
         try {
-          compiled = _.template(src, false, options.templateSettings).source;
+          compiled = options.template(src, false, options.templateSettings).source;
         } catch (e) {
           grunt.log.error(e);
           grunt.fail.warn('JST "' + filepath + '" failed to compile.');


### PR DESCRIPTION
this add a simple option that allows to set the compiler to be used. This allows to compile Mustache or other types of templates to JST with the same code
