### PR TITLE
Make processName example clearer

### DIFF
--- a/docs/jst-options.md
+++ b/docs/jst-options.md
@@ -20,8 +20,8 @@ This option accepts a function which takes one argument (the template filepath) 
 
 ```js
 options: {
-  processName: function(filename) {
-    return filename.toUpperCase();
+  processName: function(filepath) {
+    return filepath.toUpperCase();
   }
 }
 ```


### PR DESCRIPTION
The description for processName says the function is passed the filepath but the example uses an argument named `filename`. This change makes it clearer that the filepath is being passed to the function
