### PR TITLE
add prepend option

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,44 @@ options: {
 }
 ```
 
+#### prepend
+Type: `function` or `string`
+
+The variables declared before compiling templates, which will be prepend
+to the generated template files. It is usefull when one just need the `_.template()`
+method but don't want to use the whole underscore or lodash lib. If the option `prettify`
+is `true` then all whitespaces in the prepend string will be removed.
+
+```js
+jst: {
+  prepend: function() {
+    var vars = function() {
+      var _ = {};
+
+      _.escape = function() {
+        var escapeMap = {
+            '&': '&amp;',
+            '<': '&lt;',
+            '>': '&gt;',
+            '"': '&quot;',
+            "'": '&#x27;'
+        };
+        var escapeRegexe = new RegExp('[' + Object.keys(escapeMap).join('') + ']', 'g');
+
+        if (string == null) return '';
+        return ('' + string).replace(escapeRegexe, function(match) {
+            return escapeMap[match];
+        });
+      };
+    };
+
+    var entire = vars.toString();
+
+    return entire.slice(entire.indexOf('{') + 1, entire.lastIndexOf('}'));
+  }
+}
+```
+
 ### Usage Examples
 
 ```js

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "underscore": "~1.6.0",
+    "lodash": "~2.4.1",
     "grunt-lib-contrib": "~0.7.0",
     "chalk": "~0.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "lodash": "~2.4.1",
+    "underscore": "~1.6.0",
     "grunt-lib-contrib": "~0.7.0",
     "chalk": "~0.4.0"
   },

--- a/tasks/jst.js
+++ b/tasks/jst.js
@@ -7,7 +7,7 @@
  */
 
 'use strict';
-var _ = require('lodash');
+var _ = require('underscore');
 var chalk = require('chalk');
 
 module.exports = function(grunt) {

--- a/tasks/jst.js
+++ b/tasks/jst.js
@@ -7,7 +7,7 @@
  */
 
 'use strict';
-var _ = require('underscore');
+var _ = require('lodash');
 var chalk = require('chalk');
 
 module.exports = function(grunt) {
@@ -69,6 +69,15 @@ module.exports = function(grunt) {
       } else {
         if (options.namespace !== false) {
           output.unshift(nsInfo.declaration);
+        }
+        if(options.prepend) {
+          var prepend = options.prepend;
+
+          if(typeof prepend === 'function') prepend = prepend();
+
+          if(options.prettify) prepend = prepend.replace(/(^\s+|\s+$)/gm, '');
+
+          output.unshift(prepend);
         }
         if (options.amd) {
           if (options.prettify) {


### PR DESCRIPTION
Prepend some variables to the compiled template file, it makes the compiled file can run alone, then we will do not need to add underscore or lodash lib using <script> tag in the html files.