### PR TITLE
Add underscore dependency to AMD wrapper.

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Default: false
 Wraps the output file with an AMD define function and returns the compiled template namespace unless namespace has been explicitly set to false in which case the template function will be returned directly.
 
 ```js
-define(function() {
+define(['underscore'], function(_){
     //...//
     return this['[template namespace]'];
 });

--- a/docs/jst-options.md
+++ b/docs/jst-options.md
@@ -68,7 +68,7 @@ Default: false
 Wraps the output file with an AMD define function and returns the compiled template namespace unless namespace has been explicitly set to false in which case the template function will be returned directly.
 
 ```js
-define(function() {
+define(['underscore'], function(_){
     //...//
     return this['[template namespace]'];
 });

--- a/tasks/jst.js
+++ b/tasks/jst.js
@@ -76,7 +76,7 @@ module.exports = function(grunt) {
               output[index] = "  " + line;
             });
           }
-          output.unshift("define(function(){");
+          output.unshift("define(['underscore'], function(_){");
           if (options.namespace !== false) {
             // Namespace has not been explicitly set to false; the AMD
             // wrapper will return the object containing the template.

--- a/test/expected/amd_wrapper.js
+++ b/test/expected/amd_wrapper.js
@@ -1,4 +1,4 @@
-define(function(){
+define(['underscore'], function(_){
 
 this["JST"] = this["JST"] || {};
 

--- a/test/expected/amd_wrapper_no_ns.js
+++ b/test/expected/amd_wrapper_no_ns.js
@@ -1,4 +1,4 @@
-define(function(){
+define(['underscore'], function(_){
 
 return function(obj) {
 var __t, __p = '', __e = _.escape;

--- a/test/expected/pretty_amd.js
+++ b/test/expected/pretty_amd.js
@@ -1,4 +1,4 @@
-define(function(){
+define(['underscore'], function(_){
 
   this["JST"] = this["JST"] || {};
 


### PR DESCRIPTION
I was getting errors with methods like `_.escape` being undefined as I'm using Lo-Dash with `_.noConflict()`.