### PR TITLE
use amd option to specify custom module name as dependence

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -86,6 +86,18 @@ module.exports = function(grunt) {
           "tmp/amd_wrapper_no_ns.js": ["test/fixtures/template.html"]
         }
       },
+      amd_string_no_ns: {
+        options: {
+          templateSettings: {
+            variable: 'obj'
+          },
+          amd:'lodash',
+          namespace:false
+        },
+        files: {
+          "tmp/amd_string_no_ns.js": ["test/fixtures/template.html"]
+        }
+      },
       uglyfile: {
         options: {
           templateSettings: {

--- a/README.md
+++ b/README.md
@@ -93,23 +93,44 @@ options: {
 ```
 
 #### amd
-Type: `boolean`
-Default: false
+Type: `boolean` or `String`
+Default: `false`
 
 Wraps the output file with an AMD define function and returns the compiled template namespace unless namespace has been explicitly set to false in which case the template function will be returned directly.
 
-```js
-define(function() {
-    //...//
-    return this['[template namespace]'];
-});
-```
+If `true` then the module name `'underscore'` will be uesed as first dependence of the AMD module.
+
+If `String` then you can provide a custom module name to be used as the first dependence.
+
+And the first dependence is expected to be underscore.js or underscore-compatible lib like [lodash.js](https://lodash.com/), in fact, grunt-contrib-jst just use lodash.js to pre-compile templates.
 
 Example:
 ```js
 options: {
   amd: true
 }
+```
+
+will output:
+```js
+define(['underscore'], function(_) {
+  //...//
+  return this['[template namespace]'];
+});
+```
+
+```js
+options: {
+  amd: 'lodash'
+}
+```
+
+will output:
+```js
+define(['lodash'], function(_) {
+  //...//
+  return this['[template namespace]'];
+});
 ```
 
 #### processContent
@@ -166,4 +187,4 @@ Note that the `interpolate: /\{\{(.+?)\}\}/g` setting above is simply an example
 
 Task submitted by [Tim Branyen](http://tbranyen.com)
 
-*This file was generated on Fri Jul 11 2014 10:15:42.*
+*This file was generated on Fri Oct 17 2014 00:37:23.*

--- a/docs/jst-options.md
+++ b/docs/jst-options.md
@@ -62,23 +62,44 @@ options: {
 ```
 
 ## amd
-Type: `boolean`
-Default: false
+Type: `boolean` or `String`
+Default: `false`
 
 Wraps the output file with an AMD define function and returns the compiled template namespace unless namespace has been explicitly set to false in which case the template function will be returned directly.
 
-```js
-define(function() {
-    //...//
-    return this['[template namespace]'];
-});
-```
+If `true` then the module name `'underscore'` will be uesed as first dependence of the AMD module.
+
+If `String` then you can provide a custom module name to be used as the first dependence.
+
+And the first dependence is expected to be underscore.js or underscore-compatible lib like [lodash.js](https://lodash.com/), in fact, grunt-contrib-jst just use lodash.js to pre-compile templates.
 
 Example:
 ```js
 options: {
   amd: true
 }
+```
+
+will output:
+```js
+define(['underscore'], function(_) {
+  //...//
+  return this['[template namespace]'];
+});
+```
+
+```js
+options: {
+  amd: 'lodash'
+}
+```
+
+will output:
+```js
+define(['lodash'], function(_) {
+  //...//
+  return this['[template namespace]'];
+});
 ```
 
 ## processContent

--- a/tasks/jst.js
+++ b/tasks/jst.js
@@ -89,7 +89,7 @@ module.exports = function(grunt) {
           }
           output.push("});");
         }
-        grunt.file.write(f.dest, output.join(grunt.util.normalizelf(options.separator)));
+        grunt.file.write(f.dest, grunt.util.normalizelf(output.join(options.separator)));
         grunt.log.writeln('File ' + chalk.cyan(f.dest) + ' created.');
       }
     });

--- a/tasks/jst.js
+++ b/tasks/jst.js
@@ -80,19 +80,6 @@ module.exports = function(grunt) {
             output.unshift("define(['underscore'], function(_) {");
           } else if (typeof options.amd === 'string') {
             output.unshift("define(['" + options.amd + "'], function(_) {");
-          } else if (Array.isArray(options.amd)) {
-            // convert options.amd to a string of dependencies for require([...])
-            var dependenciesString = '';
-            for (var i = 0; i < options.amd.length; i++) {
-              if (i !== 0) {
-                dependenciesString += ', ';
-              }
-
-              dependenciesString += "'" + options.amd[i] + "'";
-            }
-
-            // Wrap the file in an AMD define fn.
-            output.unshift("define([" + dependenciesString + "], function(_) {");
           }
 
           if (options.namespace !== false) {

--- a/tasks/jst.js
+++ b/tasks/jst.js
@@ -76,11 +76,29 @@ module.exports = function(grunt) {
               output[index] = "  " + line;
             });
           }
-          output.unshift("define(function(){");
+          if (typeof options.amd === "boolean") {
+            output.unshift("define(['underscore'], function(_) {");
+          } else if (typeof options.amd === 'string') {
+            output.unshift("define(['" + options.amd + "'], function(_) {");
+          } else if (Array.isArray(options.amd)) {
+            // convert options.amd to a string of dependencies for require([...])
+            var dependenciesString = '';
+            for (var i = 0; i < options.amd.length; i++) {
+              if (i !== 0) {
+                dependenciesString += ', ';
+              }
+
+              dependenciesString += "'" + options.amd[i] + "'";
+            }
+
+            // Wrap the file in an AMD define fn.
+            output.unshift("define([" + dependenciesString + "], function(_) {");
+          }
+
           if (options.namespace !== false) {
             // Namespace has not been explicitly set to false; the AMD
             // wrapper will return the object containing the template.
-            output.push("  return " + nsInfo.namespace + ";");
+            output.push((options.prettify ? "  " : '') + "return " + nsInfo.namespace + ";");
           }
           output.push("});");
         }

--- a/test/expected/amd_string_no_ns.js
+++ b/test/expected/amd_string_no_ns.js
@@ -1,4 +1,4 @@
-define(['underscore'], function(_) {
+define(['lodash'], function(_) {
 
 return function(obj) {
 var __t, __p = '', __e = _.escape;

--- a/test/expected/amd_wrapper.js
+++ b/test/expected/amd_wrapper.js
@@ -1,4 +1,4 @@
-define(function(){
+define(['underscore'], function(_) {
 
 this["JST"] = this["JST"] || {};
 
@@ -10,6 +10,6 @@ __p += '<head><title>' +
 return __p
 };
 
-  return this["JST"];
+return this["JST"];
 
 });

--- a/test/expected/pretty_amd.js
+++ b/test/expected/pretty_amd.js
@@ -1,4 +1,4 @@
-define(function(){
+define(['underscore'], function(_) {
 
   this["JST"] = this["JST"] || {};
 

--- a/test/expected/process_content.js
+++ b/test/expected/process_content.js
@@ -2,8 +2,8 @@ this["JST"] = this["JST"] || {};
 
 this["JST"]["test/fixtures/indent_template.html"] = function(obj) {
 var __t, __p = '', __e = _.escape;
-__p += '<div>\n<div>\n<div>\n' +
+__p += '<div><div><div>' +
 ((__t = ( obj.name )) == null ? '' : __t) +
-'\n</div>\n</div>\n</div>';
+'</div></div></div>';
 return __p
 };

--- a/test/jst_test.js
+++ b/test/jst_test.js
@@ -6,7 +6,7 @@ exports['jst'] = {
 
     var expect, result;
 
-    test.expect(10);
+    test.expect(11);
 
     expect = grunt.file.read("test/expected/jst.js");
     result = grunt.file.read("tmp/jst.js");
@@ -35,7 +35,11 @@ exports['jst'] = {
     expect = grunt.file.read("test/expected/amd_wrapper_no_ns.js");
     result = grunt.file.read("tmp/amd_wrapper_no_ns.js");
     test.equal(expect, result, "should wrap the template with define for AMD pattern and return the function itself with no namespace");
-    
+
+    expect = grunt.file.read("test/expected/amd_string_no_ns.js");
+    result = grunt.file.read("tmp/amd_string_no_ns.js");
+    test.equal(expect, result, "should wrap everything with an AMD define block and have a custom module name");
+
     expect = grunt.file.read("test/expected/pretty_amd.js"); 
     result = grunt.file.read("tmp/pretty_amd.js");
     test.equal(expect, result, "should make the AMD wrapper output pretty");


### PR DESCRIPTION
Support providing `String` value to `amd` option to specify custom module name as the first dependence, which should be underscore.js or lodash.js or any API-compatibled AMD module.
