### PR TITLE
processContent(content, filepath)

### DIFF
--- a/tasks/jst.js
+++ b/tasks/jst.js
@@ -43,7 +43,7 @@ module.exports = function(grunt) {
         }
       })
       .map(function(filepath) {
-        var src = options.processContent(grunt.file.read(filepath));
+        var src = options.processContent(grunt.file.read(filepath), filepath);
         var compiled, filename;
 
         try {


### PR DESCRIPTION
I wanted to be able to access filepath in the processContent. My use case was to wrap a template in a begin and end comment that included the source filepath.
