### PR TITLE
Sending filepath in second parameter

### DIFF
--- a/tasks/jst.js
+++ b/tasks/jst.js
@@ -43,7 +43,7 @@ module.exports = function(grunt) {
         }
       })
       .map(function(filepath) {
-        var src = options.processContent(grunt.file.read(filepath));
+        var src = options.processContent(grunt.file.read(filepath),filepath);
         var compiled, filename;
 
         try {


### PR DESCRIPTION
So that one can change write the logic of processing contents that depends on filename/filepath